### PR TITLE
chore(package): pinned dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "history": "^1.11.1",
     "i18next-client": "^1.10.2",
     "i18next-resource-store-loader": "^0.0.3",
-    "material-ui": "^0.12.1",
+    "material-ui": "0.12.4",
     "normalize.css": "^3.0.3",
     "parse-link-header": "^0.4.1",
     "react": "^0.14.0",


### PR DESCRIPTION
pin material_ui to 0.12.4

fixes build error:

```bash
npm ERR! peerinvalid The package react@0.14.3 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer material-ui@0.12.5 wants react@~0.13
npm ERR! peerinvalid Peer react-dom@0.14.3 wants react@^0.14.3
npm ERR! peerinvalid Peer react-redux@4.0.0 wants react@^0.14.0
npm ERR! peerinvalid Peer react-tap-event-plugin@0.2.1 wants react@^0.14.0
npm ERR! peerinvalid Peer redbox-react@1.2.0 wants react@>=0.13.2 || ^0.14.0-rc1

```